### PR TITLE
Update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .idea/
 node_modules/
-coverage/
+.nyc_output/
 package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-   - "4"
-   - "6"
-   - "8"
+   - "10"
+   - "12"
+   - "14"
 script:
    npm run travis

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const through = require('through2');
 const decomment = require('decomment');
-const PluginError = require('gulp-util').PluginError;
+const PluginError = require('plugin-error');
 
 function main(options, func) {
     return through.obj(function (file, enc, cb) {
@@ -11,9 +11,9 @@ function main(options, func) {
             return;
         }
         if (file.isStream()) {
-            cb(new PluginError('gulp-decomment', 'Streaming not supported.'));
+            cb(new PluginError({plugin:'gulp-decomment', message: 'Streaming not supported.'}));
         }
-        file.contents = new Buffer(func(file.contents.toString(), options));
+        file.contents = Buffer.from(func(file.contents.toString(), options));
         this.push(file);
         return cb();
     });

--- a/package.json
+++ b/package.json
@@ -34,18 +34,19 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=4.0",
-    "npm": ">=2.15"
+    "node": ">=10.24",
+    "npm": ">=6.14"
   },
   "dependencies": {
-    "decomment": "~0.9.1",
-    "gulp-util": "~3.0.8",
+    "decomment": "~0.9.3",
+    "plugin-error": "^1.0.1",
     "through2": "^2.0.3"
   },
   "devDependencies": {
     "coveralls": "~2.11.16",
     "eslint": "~4.7.0",
     "istanbul": "~0.4.5",
-    "jasmine-node": "~1.14.5"
+    "jasmine-node": "~1.14.5",
+    "vinyl": "^2.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "0.2.0",
   "description": "Removes comments from JSON, JavaScript, CSS, HTML, etc.",
   "scripts": {
-    "test": "jasmine-node test",
-    "coverage": "istanbul cover ./node_modules/jasmine-node/bin/jasmine-node test",
-    "travis": "npm run lint && istanbul cover ./node_modules/jasmine-node/bin/jasmine-node test --captureExceptions && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
-    "lint": "./node_modules/.bin/eslint ./index.js ./test"
+    "test": "jasmine test/**",
+    "coverage": "nyc npm run test",
+    "lint": "eslint ./index.js ./test",
+    "travis": "npm run lint && npm run coverage && nyc report --reporter=text-lcov | coveralls && rm -rf ./.nyc_output"
   },
   "files": [
     "index.js"
@@ -43,10 +43,10 @@
     "through2": "^2.0.3"
   },
   "devDependencies": {
-    "coveralls": "~2.11.16",
+    "coveralls": "^3.1.0",
     "eslint": "~4.7.0",
-    "istanbul": "~0.4.5",
-    "jasmine-node": "~1.14.5",
+    "jasmine": "^3.6.4",
+    "nyc": "^15.1.0",
     "vinyl": "^2.2.1"
   }
 }

--- a/test/mainSpec.js
+++ b/test/mainSpec.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const decomment = require('../');
-const util = require('gulp-util');
+const Vinyl = require('vinyl');
+const PluginError = require('plugin-error');
 const stream = require('stream');
 
 ////////////////////////
@@ -88,14 +89,14 @@ describe('Negative:', () => {
                 err = e;
                 done();
             }
-            expect(err instanceof util.PluginError);
+            expect(err instanceof PluginError);
             expect(err.message).toBe('Streaming not supported.');
         });
     });
 });
 
 function getFakeDest(content) {
-    return new util.File({
+    return new Vinyl({
         path: './test/fixture/test.js',
         cwd: './test/',
         base: './test/fixture/',
@@ -104,7 +105,7 @@ function getFakeDest(content) {
 }
 
 function getBuffer(bufferContent) {
-    return getFakeDest(new Buffer(bufferContent));
+    return getFakeDest(Buffer.from(bufferContent));
 }
 
 function getNull() {


### PR DESCRIPTION
Hello @vitaly-t
We'd like to evaluate and maybe use your gulp-decomment for stripping html comments in our webapp.
So far we've been using gulp-remove-html-comments which have not been updated in a longer while than
your package (and yeah, we're stuck with gulp for now).
So here is a little PR that updates a few dependencies (my main focus was on removing gulp-util).
through2 and eslint would need updating too ; that's for later.

I chose to mark support for Node's currently active LTS (10, 12 and 14). I let you chose the appropriate semver for your package
in case you accept the PR.

Cheers,
Stéphane